### PR TITLE
reduce dialback timeout to 15s

### DIFF
--- a/svc.go
+++ b/svc.go
@@ -21,7 +21,7 @@ import (
 const P_CIRCUIT = 290
 
 var (
-	AutoNATServiceDialTimeout   = 42 * time.Second
+	AutoNATServiceDialTimeout   = 15 * time.Second
 	AutoNATServiceResetInterval = 1 * time.Minute
 
 	AutoNATServiceThrottle = 3


### PR DESCRIPTION
42 is a nice round number, but it turns out it's tooo long.